### PR TITLE
add managed code (.net) check

### DIFF
--- a/pe/file.go
+++ b/pe/file.go
@@ -508,3 +508,19 @@ func (f *File) RVAToFileOffset(rva uint32) uint32 {
 	}
 	return offset
 }
+
+//IsManaged returns true if the loaded PE file references the CLR header (aka is a .net exe)
+func (f *File) IsManaged() bool {
+	switch v := f.OptionalHeader.(type) {
+	case *OptionalHeader32:
+		if v.DataDirectory[IMAGE_DIRECTORY_ENTRY_COM_DESCRIPTOR].VirtualAddress != 0 {
+			return true
+		}
+	case *OptionalHeader64:
+		if v.DataDirectory[IMAGE_DIRECTORY_ENTRY_COM_DESCRIPTOR].VirtualAddress != 0 {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
I found myself doing this check a bunch, so figured it might be a good addition to the lib.

ref: https://reverseengineering.stackexchange.com/questions/1614/determining-if-a-file-is-managed-code-or-not/1620#1620

I'm not sure what this comment means:

> there is a significant difference: using the #define means a 32-bit program will recognise only a 32-bit program, 64-bit will only recognise 64-bit. This is why I suggested using the hard-coded values.

but I think that's covered by the type switch... happy to just use hard-coded values if that ends up being the most reliable way tbh.

The function name could probably be changed to 'hasmanaged', as the `VirtualAddress` will be non-zero if the CLR is used by the binary at all (eg mixed mode assemblies), but I would never remember the name.

