### PR TITLE
fix up strings table location when in memory

### DIFF
--- a/pe/file.go
+++ b/pe/file.go
@@ -17,7 +17,10 @@ import (
 )
 
 // Avoid use of post-Go 1.4 io features, to make safe for toolchain bootstrap.
-const seekStart = 0
+const (
+	seekStart   = 0
+	seekCurrent = 1
+)
 
 // A File represents an open PE file.
 type File struct {
@@ -139,7 +142,7 @@ func newFileInternal(r io.ReaderAt, memoryMode bool) (*File, error) {
 
 	if memoryMode {
 		//get strings table location - offset is wrong in the header because we are in memory mode. Can we fix it? Yes we can!
-		restore, err := sr.Seek(0, io.SeekCurrent)
+		restore, err := sr.Seek(0, seekCurrent)
 		if err != nil {
 			return nil, fmt.Errorf("Had a bad time getting restore point: ", err)
 		}
@@ -157,8 +160,8 @@ func newFileInternal(r io.ReaderAt, memoryMode bool) (*File, error) {
 				f.FileHeader.PointerToSymbolTable = sh.VirtualAddress
 			}
 		}
+		//restore the original location of sr (this shouldn't actually be required, but just in case)
 		sr.Seek(restore, seekStart)
-
 	}
 
 	// Read string table.

--- a/pe/write.go
+++ b/pe/write.go
@@ -80,6 +80,13 @@ func (peFile *File) Bytes() ([]byte, error) {
 			NumberOfLineNumbers:  section.NumberOfLineNumbers,
 			Characteristics:      section.Characteristics,
 		}
+
+		// if the PE file was pulled from memory, the symbol table offset in the header will be wrong.
+		// Fix it up by picking the section that lines up, and use the raw offset instead.
+		if peFile.FileHeader.PointerToSymbolTable == sectionHeader.VirtualAddress {
+			peFile.FileHeader.PointerToSymbolTable = sectionHeader.PointerToRawData
+		}
+
 		sectionHeaders[idx] = sectionHeader
 
 		//log.Printf("section: %+v\nsectionHeader: %+v\n", section, sectionHeader)


### PR DESCRIPTION
This should fix up the symbols table location when working in memory.

I haven't checked if this will impact the binary if you're re-writing it to disk from in-memory, suggest adding a check to convert it back when writing it if that's the case (same tactic should work - iterate through the sections until the offsets match up and then be happy)