### PR TITLE
Add ability to retrieve CLR version from exe

### DIFF
--- a/pe/net.go
+++ b/pe/net.go
@@ -1,0 +1,69 @@
+package pe
+
+import (
+	"encoding/binary"
+	"io"
+)
+
+type IMAGE_COR20_HEADER struct {
+	Cb                        uint32
+	MajorRuntimeVersion       uint16
+	MinorRuntimeVersion       uint16
+	MetaDataRVA, MetaDataSize uint32
+	Flags                     uint32 //todo: define flags
+	EntryPointToken           uint32
+	ResourcesRVA, ResourcesSize,
+	StrongNameSignatureRVA, StrongNameSignatureSize,
+	CodeManagerTableRVA, CodeManagerTableSize,
+	VTableFixupsRVA, VTableFixupsSize,
+	ExportAddressTableJumpsRVA, ExportAddressTableJumpsSize,
+	ManagedNativeHeaderRVA, ManagedNativeHeaderSize uint32
+}
+
+//Net provides a public interface for getting at some net info.
+type Net struct {
+	NetDirectory IMAGE_COR20_HEADER //Net directory information
+	MetaData     NetMetaData        //MetaData Header
+}
+
+type NetMetaData struct {
+	Signature       [4]byte //should be 0x424a4542
+	MajorVersion    uint16
+	MinorVersion    uint16
+	Reserved        uint32
+	VersionLength   uint32
+	VersionString   []byte
+	Flags           uint16 //todo: define flags betterer
+	NumberOfStreams uint16
+}
+
+func newMetadataHeader(i io.Reader) (NetMetaData, error) {
+	r := NetMetaData{}
+
+	//todo: error checks/sanity checks
+	binary.Read(i, binary.LittleEndian, &r.Signature)
+	binary.Read(i, binary.LittleEndian, &r.MajorVersion)
+	binary.Read(i, binary.LittleEndian, &r.MinorVersion)
+	binary.Read(i, binary.LittleEndian, &r.Reserved)
+
+	// it appears that this value is terminated by two nulls.. that might be important at some point
+	binary.Read(i, binary.LittleEndian, &r.VersionLength)
+	r.VersionString = make([]byte, r.VersionLength)
+	i.Read(r.VersionString)
+
+	binary.Read(i, binary.LittleEndian, r.Flags)
+
+	return r, nil
+}
+
+//GetCLRVersion returns the CLR version specified by the binary. Returns an empty string if not a net binary. String has had trailing nulls stripped.
+func (f File) GetCLRVersion() string {
+	b := f.Net.MetaData.VersionString
+	for i, x := range b {
+		if x == 0x00 {
+			b = b[:i]
+			break
+		}
+	}
+	return string(b)
+}

--- a/pe/net.go
+++ b/pe/net.go
@@ -56,8 +56,8 @@ func newMetadataHeader(i io.Reader) (NetMetaData, error) {
 	return r, nil
 }
 
-//GetCLRVersion returns the CLR version specified by the binary. Returns an empty string if not a net binary. String has had trailing nulls stripped.
-func (f File) GetCLRVersion() string {
+//NetCLRVersion returns the CLR version specified by the binary. Returns an empty string if not a net binary. String has had trailing nulls stripped.
+func (f File) NetCLRVersion() string {
 	b := f.Net.MetaData.VersionString
 	for i, x := range b {
 		if x == 0x00 {


### PR DESCRIPTION
I'm not sold on the implementation of this (adding a member to the File type seems a bit clunky to me), I'm open to an alternate approach, I just can't think of one at present. There is _a lot_ of .net specific structs that could probably be added to this.

I also cannot emphasise enough that I did almost no testing against lots of .net executables. It could do with being pointed at a large corpus to see what breaks.

Something else worth pointing out is that the version string is stored with the terminating nulls preserved, but the function to return the version string strips the nulls. Demo below:
```
package main

import (
	"fmt"

	"github.com/Binject/debug/pe"
)

func main() {
	f, err := pe.Open(`C:\windows\system32\filehistory.exe`)
	if err != nil {
		panic(err)
	}

	x := string(f.Net.MetaData.VersionString)
	y := f.NetCLRVersion()

	fmt.Println(x == y, []byte(x), []byte(y), f.NetCLRVersion())

}
```
->
```
false [118 52 46 48 46 51 48 51 49 57 0 0] [118 52 46 48 46 51 48 51 49 57] v4.0.30319
```
